### PR TITLE
Fix Help redirect

### DIFF
--- a/MAS/All-In-One-Version/MAS_AIO.cmd
+++ b/MAS/All-In-One-Version/MAS_AIO.cmd
@@ -258,7 +258,7 @@ choice /C:123456780 /N
 set _erl=%errorlevel%
 
 if %_erl%==9 exit /b
-if %_erl%==8 start https://%mas%/troubleshoot.html & goto :MainMenu
+if %_erl%==8 start %mas%troubleshoot.html & goto :MainMenu
 if %_erl%==7 goto:Extras
 if %_erl%==6 setlocal & call :troubleshoot      & cls & endlocal & goto :MainMenu
 if %_erl%==5 setlocal & call :_Check_Status_wmi & cls & endlocal & goto :MainMenu


### PR DESCRIPTION
Instead of redirecting to https://massgrave.dev/troubleshoot.html it incorrectly redirects to https://https//massgrave.dev//troubleshoot.html

Fixes issue #278 