### PR TITLE
Call Powershell with -NoProfile flag

### DIFF
--- a/MAS/All-In-One-Version-KL/MAS_AIO.cmd
+++ b/MAS/All-In-One-Version-KL/MAS_AIO.cmd
@@ -997,7 +997,7 @@ goto :dk_done
 
 :dk_setvar
 
-set psc=powershell.exe
+set psc=powershell.exe -nop
 set winbuild=1
 for /f "tokens=6 delims=[]. " %%G in ('ver') do set winbuild=%%G
 
@@ -5436,7 +5436,7 @@ set _tserror=
 set winbuild=1
 set "nul=>nul 2>&1"
 for /f "tokens=6 delims=[]. " %%G in ('ver') do set winbuild=%%G
-set psc=powershell.exe
+set psc=powershell.exe -nop
 
 set run_once=
 set t_name=Renewal Task

--- a/MAS/Separate-Files-Version/Activators/HWID_Activation.cmd
+++ b/MAS/Separate-Files-Version/Activators/HWID_Activation.cmd
@@ -760,7 +760,7 @@ goto :dk_done
 
 :dk_setvar
 
-set psc=powershell.exe
+set psc=powershell.exe -nop
 set winbuild=1
 for /f "tokens=6 delims=[]. " %%G in ('ver') do set winbuild=%%G
 

--- a/MAS/Separate-Files-Version/Activators/KMS38_Activation.cmd
+++ b/MAS/Separate-Files-Version/Activators/KMS38_Activation.cmd
@@ -869,7 +869,7 @@ $key.SetAccessControl($acl)
 
 :dk_setvar
 
-set psc=powershell.exe
+set psc=powershell.exe -nop
 set winbuild=1
 for /f "tokens=6 delims=[]. " %%G in ('ver') do set winbuild=%%G
 

--- a/MAS/Separate-Files-Version/Activators/Ohook_Activation_AIO.cmd
+++ b/MAS/Separate-Files-Version/Activators/Ohook_Activation_AIO.cmd
@@ -1350,7 +1350,7 @@ exit /b
 
 :dk_setvar
 
-set psc=powershell.exe
+set psc=powershell.exe -nop
 set winbuild=1
 for /f "tokens=6 delims=[]. " %%G in ('ver') do set winbuild=%%G
 

--- a/MAS/Separate-Files-Version/Activators/Online_KMS_Activation.cmd
+++ b/MAS/Separate-Files-Version/Activators/Online_KMS_Activation.cmd
@@ -1615,7 +1615,7 @@ set _tserror=
 set winbuild=1
 set "nul=>nul 2>&1"
 for /f "tokens=6 delims=[]. " %%G in ('ver') do set winbuild=%%G
-set psc=powershell.exe
+set psc=powershell.exe -nop
 
 set run_once=
 set t_name=Renewal Task
@@ -2302,7 +2302,7 @@ exit /b
 
 :dk_setvar
 
-set psc=powershell.exe
+set psc=powershell.exe -nop
 set winbuild=1
 for /f "tokens=6 delims=[]. " %%G in ('ver') do set winbuild=%%G
 

--- a/MAS/Separate-Files-Version/Change_Office_Edition.cmd
+++ b/MAS/Separate-Files-Version/Change_Office_Edition.cmd
@@ -1308,7 +1308,7 @@ if ($appIdsList.Count -gt 0) {
 
 :dk_setvar
 
-set psc=powershell.exe
+set psc=powershell.exe -nop
 set winbuild=1
 for /f "tokens=6 delims=[]. " %%G in ('ver') do set winbuild=%%G
 

--- a/MAS/Separate-Files-Version/Change_Windows_Edition.cmd
+++ b/MAS/Separate-Files-Version/Change_Windows_Edition.cmd
@@ -780,7 +780,7 @@ exit /b
 
 :dk_setvar
 
-set psc=powershell.exe
+set psc=powershell.exe -nop
 set winbuild=1
 for /f "tokens=6 delims=[]. " %%G in ('ver') do set winbuild=%%G
 

--- a/MAS/Separate-Files-Version/Troubleshoot.cmd
+++ b/MAS/Separate-Files-Version/Troubleshoot.cmd
@@ -1425,7 +1425,7 @@ exit /b
 
 :dk_setvar
 
-set psc=powershell.exe
+set psc=powershell.exe -nop
 set winbuild=1
 for /f "tokens=6 delims=[]. " %%G in ('ver') do set winbuild=%%G
 


### PR DESCRIPTION
Ensures Powershell code is run a clean environment without user-specific profile code. Fixes an obscure bug where unexpected output from profile loading breaks the script parsing.